### PR TITLE
Service-specific OwsServiceProviders

### DIFF
--- a/src/main/java/org/n52/iceland/exception/ows/CompositeOwsException.java
+++ b/src/main/java/org/n52/iceland/exception/ows/CompositeOwsException.java
@@ -27,15 +27,15 @@ import org.n52.iceland.exception.CodedException;
 /**
  * Composite {@link OwsExceptionReport} which can contain several
  * {@link OwsExceptionReport}s which were thrown
- * 
+ *
  * @author Christian Autermann <c.autermann@52north.org>
- * 
+ *
  * @since 1.0.0
  */
 public class CompositeOwsException extends OwsExceptionReport {
     private static final long serialVersionUID = -4876354677532448922L;
 
-    private List<CodedException> exceptions = new LinkedList<CodedException>();
+    private final List<CodedException> exceptions = new LinkedList<>();
 
     public CompositeOwsException(OwsExceptionReport... exceptions) {
         add(exceptions);
@@ -48,11 +48,12 @@ public class CompositeOwsException extends OwsExceptionReport {
     public CompositeOwsException() {
     }
 
-    public CompositeOwsException add(Collection<? extends OwsExceptionReport> exceptions) {
+    public final CompositeOwsException add(Collection<? extends OwsExceptionReport> exceptions) {
         if (exceptions != null) {
-            for (OwsExceptionReport e : exceptions) {
-                this.exceptions.addAll(e.getExceptions());
-            }
+            exceptions.stream()
+                    .map(OwsExceptionReport::getExceptions)
+                    .forEach(this.exceptions::addAll);
+
             if (getCause() == null && !this.exceptions.isEmpty()) {
                 initCause(this.exceptions.get(0));
             }
@@ -60,7 +61,7 @@ public class CompositeOwsException extends OwsExceptionReport {
         return this;
     }
 
-    public CompositeOwsException add(OwsExceptionReport... exceptions) {
+    public final CompositeOwsException add(OwsExceptionReport... exceptions) {
         return add(Arrays.asList(exceptions));
     }
 
@@ -79,7 +80,11 @@ public class CompositeOwsException extends OwsExceptionReport {
         return this.exceptions.size();
     }
 
+    public boolean isEmpty() {
+        return this.exceptions.isEmpty();
+    }
+
     public boolean hasExceptions() {
-        return !this.exceptions.isEmpty();
+        return !isEmpty();
     }
 }

--- a/src/main/java/org/n52/iceland/i18n/LocaleHelper.java
+++ b/src/main/java/org/n52/iceland/i18n/LocaleHelper.java
@@ -39,6 +39,10 @@ public class LocaleHelper {
         return decoder.apply(locale);
     }
 
+    /**
+     * @deprecated use {@link AbstractServiceRequest#getRequestedLocale()}
+     */
+    @Deprecated
     public static Locale fromRequest(AbstractServiceRequest<?> locale) {
         return fromString(locale.getRequestedLanguage());
     }

--- a/src/main/java/org/n52/iceland/ogc/ows/ServiceIdentificationFactorySettings.java
+++ b/src/main/java/org/n52/iceland/ogc/ows/ServiceIdentificationFactorySettings.java
@@ -24,8 +24,10 @@ package org.n52.iceland.ogc.ows;
  * @since 1.0.0
  */
 public interface ServiceIdentificationFactorySettings {
+    @Deprecated
     String SERVICE_TYPE = "serviceIdentification.serviceType";
 
+    @Deprecated
     String SERVICE_TYPE_CODE_SPACE
             = "serviceIdentification.serviceTypeCodeSpace";
 

--- a/src/main/java/org/n52/iceland/ogc/ows/ServiceMetadataRepository.java
+++ b/src/main/java/org/n52/iceland/ogc/ows/ServiceMetadataRepository.java
@@ -14,37 +14,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.n52.iceland.util;
+package org.n52.iceland.ogc.ows;
 
 import java.util.Locale;
 import java.util.Set;
 
+import org.n52.iceland.util.LocalizedProducer;
+
 /**
- * Generic Factory interface.
+ * TODO JavaDoc
  *
- * @param <T>
- *            the type to produce
- *
- * @author Christian Autermann <c.autermann@52north.org>
- * @since 4.0.0
- *
+ * @author Christian Autermann
  */
-public interface LocalizedProducer<T> extends Producer<T> {
+public interface ServiceMetadataRepository {
 
-    /**
-     * Get language specific Producer result
-     *
-     * @param language
-     *                 The resulting language
-     *
-     * @return Result in the specified language
-     */
-    T get(Locale language);
+    LocalizedProducer<OwsServiceIdentification> getServiceIdentificationFactory(String service);
 
-    /**
-     * Gets the {@code Locale}s available to this {@code Producer}.
-     *
-     * @return the locales
-     */
+    LocalizedProducer<OwsServiceProvider> getServiceProviderFactory(String service);
+
     Set<Locale> getAvailableLocales();
+
 }

--- a/src/main/java/org/n52/iceland/ogc/ows/ServiceMetadataRepositoryImpl.java
+++ b/src/main/java/org/n52/iceland/ogc/ows/ServiceMetadataRepositoryImpl.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2015 52°North Initiative for Geospatial Open Source
+ * Software GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.n52.iceland.ogc.ows;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.n52.iceland.config.SettingsService;
+import org.n52.iceland.service.operator.ServiceOperatorRepository;
+import org.n52.iceland.util.LocalizedProducer;
+
+/**
+ * TODO JavaDoc
+ *
+ * @author Christian Autermann
+ */
+public class ServiceMetadataRepositoryImpl implements ServiceMetadataRepository {
+
+    private final Map<String, LocalizedProducer<OwsServiceProvider>> serviceProviders;
+    private final Map<String, LocalizedProducer<OwsServiceIdentification>> serviceIdentifications;
+
+    private SettingsService settingsService;
+    private ServiceOperatorRepository serviceOperatorRepository;
+
+    public ServiceMetadataRepositoryImpl() {
+        this.serviceProviders = Collections.synchronizedMap(new HashMap<>());
+        this.serviceIdentifications = Collections.synchronizedMap(new HashMap<>());
+    }
+
+    @Inject
+    public void setServiceOperatorRepository(ServiceOperatorRepository serviceOperatorRepository) {
+        this.serviceOperatorRepository = serviceOperatorRepository;
+    }
+
+    @Inject
+    public void setSettingsService(SettingsService settingsService) {
+        this.settingsService = settingsService;
+    }
+
+    @Override
+    public LocalizedProducer<OwsServiceIdentification> getServiceIdentificationFactory(String service) {
+        return this.serviceIdentifications.computeIfAbsent(service, this::createServiceIdentificationFactory);
+    }
+
+    @Override
+    public LocalizedProducer<OwsServiceProvider> getServiceProviderFactory(String service) {
+        return this.serviceProviders.computeIfAbsent(service, this::createServiceProviderFactory);
+    }
+
+    private LocalizedProducer<OwsServiceProvider> createServiceProviderFactory(String service) {
+        ServiceProviderFactory factory = new ServiceProviderFactory();
+        this.settingsService.configure(factory);
+        return factory;
+    }
+
+    private LocalizedProducer<OwsServiceIdentification> createServiceIdentificationFactory(String service) {
+        ServiceIdentificationFactory factory = new ServiceIdentificationFactory(service, this.serviceOperatorRepository);
+        this.settingsService.configure(factory);
+        return factory;
+    }
+
+    @Override
+    public Set<Locale> getAvailableLocales() {
+        synchronized (this.serviceProviders) {
+            return this.serviceProviders.values().stream()
+                    .map(LocalizedProducer::getAvailableLocales)
+                    .flatMap(Set::stream).collect(Collectors.toSet());
+        }
+    }
+}

--- a/src/main/java/org/n52/iceland/ogc/ows/ServiceProviderFactory.java
+++ b/src/main/java/org/n52/iceland/ogc/ows/ServiceProviderFactory.java
@@ -31,7 +31,9 @@ import static org.n52.iceland.ogc.ows.ServiceProviderFactorySettings.STATE;
 
 import java.io.File;
 import java.net.URI;
+import java.util.Collections;
 import java.util.Locale;
+import java.util.Set;
 
 import org.n52.iceland.config.annotation.Configurable;
 import org.n52.iceland.config.annotation.Setting;
@@ -138,24 +140,38 @@ public class ServiceProviderFactory extends LazyThreadSafeProducer<OwsServicePro
     protected OwsServiceProvider create(Locale language) throws ConfigurationError {
         OwsServiceProvider serviceProvider = new OwsServiceProvider();
         if (this.file != null) {
-            try {
-                serviceProvider.setServiceProvider(StringHelper.convertStreamToString(FileIOHelper.loadInputStreamFromFile(this.file)));
-            } catch (OwsExceptionReport ex) {
-                throw new ConfigurationError(ex);
-            }
+            createFromFile(serviceProvider);
         } else {
-            serviceProvider.setAdministrativeArea(this.administrativeArea);
-            serviceProvider.setCity(this.city);
-            serviceProvider.setCountry(this.country);
-            serviceProvider.setDeliveryPoint(this.deliveryPoint);
-            serviceProvider.setIndividualName(this.individualName);
-            serviceProvider.setMailAddress(this.mailAddress);
-            serviceProvider.setName(this.name);
-            serviceProvider.setPhone(this.phone);
-            serviceProvider.setPositionName(this.positionName);
-            serviceProvider.setPostalCode(this.postalCode);
-            serviceProvider.setSite(this.site == null ? null : this.site.toString());
+            createFromSettings(serviceProvider);
         }
         return serviceProvider;
+    }
+
+    private void createFromSettings(OwsServiceProvider serviceProvider) {
+        serviceProvider.setAdministrativeArea(this.administrativeArea);
+        serviceProvider.setCity(this.city);
+        serviceProvider.setCountry(this.country);
+        serviceProvider.setDeliveryPoint(this.deliveryPoint);
+        serviceProvider.setIndividualName(this.individualName);
+        serviceProvider.setMailAddress(this.mailAddress);
+        serviceProvider.setName(this.name);
+        serviceProvider.setPhone(this.phone);
+        serviceProvider.setPositionName(this.positionName);
+        serviceProvider.setPostalCode(this.postalCode);
+        serviceProvider.setSite(this.site == null ? null : this.site.toString());
+    }
+
+    private void createFromFile(OwsServiceProvider serviceProvider)
+            throws ConfigurationError {
+        try {
+            serviceProvider.setServiceProvider(StringHelper.convertStreamToString(FileIOHelper.loadInputStreamFromFile(this.file)));
+        } catch (OwsExceptionReport ex) {
+            throw new ConfigurationError(ex);
+        }
+    }
+
+    @Override
+    public Set<Locale> getAvailableLocales() {
+        return Collections.emptySet();
     }
 }

--- a/src/main/java/org/n52/iceland/request/AbstractServiceRequest.java
+++ b/src/main/java/org/n52/iceland/request/AbstractServiceRequest.java
@@ -16,12 +16,16 @@
  */
 package org.n52.iceland.request;
 
+import static org.n52.iceland.i18n.LocaleHelper.fromString;
+
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 import org.n52.iceland.exception.ows.OwsExceptionReport;
 import org.n52.iceland.exception.ows.concrete.MissingServiceParameterException;
 import org.n52.iceland.exception.ows.concrete.MissingVersionParameterException;
+import org.n52.iceland.i18n.LocaleHelper;
 import org.n52.iceland.ogc.ows.Extension;
 import org.n52.iceland.ogc.ows.Extensions;
 import org.n52.iceland.ogc.ows.OWSConstants;
@@ -133,6 +137,10 @@ public abstract class AbstractServiceRequest<T extends AbstractServiceResponse>
             }
         }
         return Constants.EMPTY_STRING;
+    }
+
+    public Locale getRequestedLocale() {
+        return LocaleHelper.fromString(getRequestedLanguage());
     }
 
     @Override

--- a/src/main/java/org/n52/iceland/request/operator/RequestOperatorRepository.java
+++ b/src/main/java/org/n52/iceland/request/operator/RequestOperatorRepository.java
@@ -19,7 +19,9 @@ package org.n52.iceland.request.operator;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -72,6 +74,14 @@ public class RequestOperatorRepository extends AbstractComponentRepository<Reque
         } else {
             return null;
         }
+    }
+
+    public Set<RequestOperator> getRequestOperators() {
+        return this.requestOperators.entrySet().stream()
+                .filter(e ->  this.activation.isActive(e.getKey()))
+                .map(Entry::getValue)
+                .map(Producer::get)
+                .collect(Collectors.toSet());
     }
 
     public RequestOperator getRequestOperator(ServiceOperatorKey sok, String operationName) {

--- a/src/main/java/org/n52/iceland/util/KvpHelper.java
+++ b/src/main/java/org/n52/iceland/util/KvpHelper.java
@@ -129,6 +129,7 @@ public final class KvpHelper {
      * @param value
      * @throws InvalidParameterValueException
      */
+    @Deprecated
     public static void checkRequestParameter(String value) throws InvalidParameterValueException {
         for (RequestOperatorKey rok : RequestOperatorRepository.getInstance().getAllRequestOperatorKeys()) {
             if (value.equals(rok.getOperationName())) {


### PR DESCRIPTION
New `ServiceMetadataRepository` that replaces the following beans: 
* `ServiceProviderFactory`
* `ServiceIdentificationFactory`
* `Producer<OwsServiceProvider>`
* `Producer<OwsServiceIdentification>`

Instead inject the `ServiceMetadataRepository` and call `getServiceIdentificationFactory(service)` and `getServiceProviderFactory(service)`.


Currently all services share the same setting, but that may change in the future. For now the service version are set according to the service and the service type is hardcoded to the following expression:
```java
"OGC:" + service
```

Service type codespace is not set. I removed the corresponding settings, as these shouldn't be changed by the user.