### PR TITLE
Use namespace from SchemaLocation as key and not from XmlEncoderKey.

### DIFF
--- a/core/src/main/java/org/n52/iceland/coding/encode/SchemaRepository.java
+++ b/core/src/main/java/org/n52/iceland/coding/encode/SchemaRepository.java
@@ -27,6 +27,7 @@ import org.n52.iceland.lifecycle.Constructable;
 import org.n52.iceland.w3c.SchemaLocation;
 
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 
 /**
  * TODO JavaDoc
@@ -59,8 +60,9 @@ public class SchemaRepository implements Constructable {
                 if (key instanceof XmlEncoderKey) {
                     Set<SchemaLocation> locations = encoder.getSchemaLocations();
                     if (locations != null && !locations.isEmpty()) {
-                        String namespace = ((XmlEncoderKey) key).getNamespace();
-                        this.schemaLocations.put(namespace, locations);
+                        for (SchemaLocation schemaLocation : locations) {
+                            this.schemaLocations.put(schemaLocation.getNamespace(), Sets.newHashSet(schemaLocation));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Use namespace from SchemaLocation as key and not from XmlEncoderKey. Because the schema location setting method fails with duplicated SchemaLocations.