### PR TITLE
Fix NPE when using MessageDigest

### DIFF
--- a/core/src/main/java/org/n52/iceland/util/JavaHelper.java
+++ b/core/src/main/java/org/n52/iceland/util/JavaHelper.java
@@ -18,10 +18,13 @@ package org.n52.iceland.util;
 
 import java.math.BigDecimal;
 import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.HashSet;
 import java.util.Set;
 
 import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Sets;
 
@@ -32,6 +35,8 @@ import com.google.common.collect.Sets;
  *
  */
 public final class JavaHelper {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JavaHelper.class);
 
     /**
      * hexadecimal values
@@ -50,11 +55,24 @@ public final class JavaHelper {
      * @param message
      *            sensor description
      * @return generated sensor id as hex SHA-1.
+     * @throws NoSuchAlgorithmException
      */
     public static String generateID(final String message) {
         final long autoGeneratredID = new DateTime().getMillis();
         final String concate = message + Long.toString(autoGeneratredID);
-        return bytesToHex(messageDigest.digest(concate.getBytes()));
+        return bytesToHex(getMessageDigest().digest(concate.getBytes()));
+    }
+
+    private static MessageDigest getMessageDigest() {
+        try {
+            if (messageDigest == null) {
+                messageDigest = MessageDigest.getInstance("SHA1");
+            }
+        } catch (final NoSuchAlgorithmException nsae) {
+            LOGGER.error("Error while getting SHA-1 messagedigest!", nsae);
+        }
+
+        return messageDigest;
     }
 
     /**

--- a/core/src/main/java/org/n52/iceland/util/JavaHelper.java
+++ b/core/src/main/java/org/n52/iceland/util/JavaHelper.java
@@ -22,6 +22,8 @@ import java.security.NoSuchAlgorithmException;
 import java.util.HashSet;
 import java.util.Set;
 
+import javax.management.RuntimeErrorException;
+
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,8 +38,6 @@ import com.google.common.collect.Sets;
  */
 public final class JavaHelper {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(JavaHelper.class);
-
     /**
      * hexadecimal values
      */
@@ -47,7 +47,7 @@ public final class JavaHelper {
     /**
      * Message digest for generating single identifier
      */
-    private static MessageDigest messageDigest;
+    private static final MessageDigest messageDigest;
 
 
     /**
@@ -57,7 +57,7 @@ public final class JavaHelper {
         try {
             messageDigest = MessageDigest.getInstance("SHA-256");
         } catch (final NoSuchAlgorithmException nsae) {
-            LOGGER.error("Error while getting SHA-256 messagedigest!", nsae);
+            throw new Error("Error while getting SHA-256 messagedigest!", nsae);
         }
     }
 

--- a/core/src/main/java/org/n52/iceland/util/JavaHelper.java
+++ b/core/src/main/java/org/n52/iceland/util/JavaHelper.java
@@ -66,7 +66,7 @@ public final class JavaHelper {
     private static MessageDigest getMessageDigest() {
         try {
             if (messageDigest == null) {
-                messageDigest = MessageDigest.getInstance("SHA1");
+                messageDigest = MessageDigest.getInstance("SHA-256");
             }
         } catch (final NoSuchAlgorithmException nsae) {
             LOGGER.error("Error while getting SHA-1 messagedigest!", nsae);

--- a/core/src/main/java/org/n52/iceland/util/JavaHelper.java
+++ b/core/src/main/java/org/n52/iceland/util/JavaHelper.java
@@ -49,30 +49,30 @@ public final class JavaHelper {
      */
     private static MessageDigest messageDigest;
 
+
+    /**
+     * Instantiation of the message digest
+     */
+    static {
+        try {
+            messageDigest = MessageDigest.getInstance("SHA-256");
+        } catch (final NoSuchAlgorithmException nsae) {
+            LOGGER.error("Error while getting SHA-256 messagedigest!", nsae);
+        }
+    }
+
     /**
      * Generates a sensor id from description and current time as long.
      *
      * @param message
      *            sensor description
-     * @return generated sensor id as hex SHA-1.
+     * @return generated sensor id as hex SHA-256.
      * @throws NoSuchAlgorithmException
      */
     public static String generateID(final String message) {
         final long autoGeneratredID = new DateTime().getMillis();
         final String concate = message + Long.toString(autoGeneratredID);
-        return bytesToHex(getMessageDigest().digest(concate.getBytes()));
-    }
-
-    private static MessageDigest getMessageDigest() {
-        try {
-            if (messageDigest == null) {
-                messageDigest = MessageDigest.getInstance("SHA-256");
-            }
-        } catch (final NoSuchAlgorithmException nsae) {
-            LOGGER.error("Error while getting SHA-1 messagedigest!", nsae);
-        }
-
-        return messageDigest;
+        return bytesToHex(messageDigest.digest(concate.getBytes()));
     }
 
     /**

--- a/core/src/test/java/org/n52/iceland/util/JavaHelperTest.java
+++ b/core/src/test/java/org/n52/iceland/util/JavaHelperTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015 52°North Initiative for Geospatial Open Source
+ * Software GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.n52.iceland.util;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class JavaHelperTest {
+
+    @Test
+    public void test_generateID() {
+        assertThat(JavaHelper.generateID("test").isEmpty(), is(false));
+    }
+
+}


### PR DESCRIPTION
- Fix NPE because the static init method was removed where the MessageDigest was initialized.
- Change algorithm
- Add simple test